### PR TITLE
Fix rounding for strings and floats

### DIFF
--- a/src/Euro.php
+++ b/src/Euro.php
@@ -54,9 +54,7 @@ final class Euro {
 			throw new InvalidArgumentException( 'Not a number' );
 		}
 
-		return new self( intval(
-			round( $euroAmount, self::$DECIMAL_COUNT ) * self::$CENTS_PER_EURO
-		) );
+		return self::newFromFloat( (float) $euroAmount );
 	}
 
 	/**
@@ -70,7 +68,10 @@ final class Euro {
 	 */
 	public static function newFromFloat( float $euroAmount ) {
 		return new self( intval(
-			round( $euroAmount, self::$DECIMAL_COUNT ) * self::$CENTS_PER_EURO
+			round(
+				round( $euroAmount, self::$DECIMAL_COUNT ) * self::$CENTS_PER_EURO,
+				0
+			)
 		) );
 	}
 

--- a/tests/Unit/EuroTest.php
+++ b/tests/Unit/EuroTest.php
@@ -132,6 +132,7 @@ class EuroTest extends TestCase {
 		$this->assertSame( 102, Euro::newFromString( '1.015' )->getEuroCents() );
 		$this->assertSame( 102, Euro::newFromString( '1.019' )->getEuroCents() );
 		$this->assertSame( 102, Euro::newFromString( '1.0199999' )->getEuroCents() );
+		$this->assertSame( 870, Euro::newFromString( '8.70' )->getEuroCents() );
 	}
 
 	public function testGivenNegativeAmountString_exceptionIsThrown() {
@@ -184,6 +185,7 @@ class EuroTest extends TestCase {
 		$this->assertSame( 102, Euro::newFromFloat( 1.015 )->getEuroCents() );
 		$this->assertSame( 102, Euro::newFromFloat( 1.019 )->getEuroCents() );
 		$this->assertSame( 102, Euro::newFromFloat( 1.0199999 )->getEuroCents() );
+		$this->assertSame( 870, Euro::newFromFloat( 8.70 )->getEuroCents() );
 	}
 
 	public function testZeroEuroIntegers_isZeroCents() {


### PR DESCRIPTION
Ref: https://phabricator.wikimedia.org/T183481

Rounding was not correct in some floating point representations such as 8.70 which evaluates to 8.69
Code inspired by https://github.com/sebastianbergmann/money/blob/master/src/Money.php