### PR TITLE
Exceptions for large numbers instead of TypeErrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ For a full CI run
 
 ## Release notes
 
+### 1.1.1 (dev)
+
+* Large numbers now cause an InvalidArgumentException rather than a TypeError
+
 ### 1.1.0 (2018-03-21)
 
 * Bumped minimum PHP version from 7.0 to 7.1

--- a/src/Euro.php
+++ b/src/Euro.php
@@ -54,12 +54,20 @@ final class Euro {
 			throw new InvalidArgumentException( 'Not a number' );
 		}
 
+		if ( self::stringIsTooLong( $euroAmount ) ) {
+			throw new InvalidArgumentException( 'Number is too big' );
+		}
+
 		$parts = explode( '.', $euroAmount, 2 );
 
 		$euros = (int)$parts[0];
 		$cents = self::centsFromString( $parts[1] ?? '0' );
 
 		return new self( $euros * self::CENTS_PER_EURO + $cents );
+	}
+
+	private static function stringIsTooLong( string $euroString ): bool {
+		return strlen( $euroString ) + 2 > log10( PHP_INT_MAX );
 	}
 
 	private static function centsFromString( string $cents ): int {
@@ -105,6 +113,10 @@ final class Euro {
 	 * @throws InvalidArgumentException
 	 */
 	public static function newFromInt( int $euroAmount ): self {
+		if ( $euroAmount > floor( PHP_INT_MAX / 101 ) ) {
+			throw new InvalidArgumentException( 'Number is too big' );
+		}
+
 		return new self( $euroAmount * self::CENTS_PER_EURO );
 	}
 

--- a/src/Euro.php
+++ b/src/Euro.php
@@ -99,6 +99,7 @@ final class Euro {
 	 * @throws InvalidArgumentException
 	 */
 	public static function newFromFloat( float $euroAmount ): self {
+		self::assertMaximumValueNotExceeded( $euroAmount );
 		return new self( intval(
 			round(
 				round( $euroAmount, self::DECIMAL_COUNT ) * self::CENTS_PER_EURO,
@@ -108,15 +109,25 @@ final class Euro {
 	}
 
 	/**
+	 * @param int|float $euroAmount
+	 */
+	private static function assertMaximumValueNotExceeded( $euroAmount ): void {
+		// When $euroAmount == PHP_INT_MAX / self::CENTS_PER_EURO, multiplying it
+		// by self::CENTS_PER_EURO still exceeds PHP_INT_MAX, which leads type errors
+		// due to float conversion. The safest thing to do here is using a safety
+		// margin of 1 with self::CENTS_PER_EURO
+		if ( $euroAmount > floor( PHP_INT_MAX / ( self::CENTS_PER_EURO + 1 ) ) ) {
+			throw new InvalidArgumentException( 'Number is too big' );
+		}
+	}
+
+	/**
 	 * @param int $euroAmount
 	 * @return self
 	 * @throws InvalidArgumentException
 	 */
 	public static function newFromInt( int $euroAmount ): self {
-		if ( $euroAmount > floor( PHP_INT_MAX / 101 ) ) {
-			throw new InvalidArgumentException( 'Number is too big' );
-		}
-
+		self::assertMaximumValueNotExceeded( $euroAmount );
 		return new self( $euroAmount * self::CENTS_PER_EURO );
 	}
 

--- a/tests/Unit/EuroTest.php
+++ b/tests/Unit/EuroTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Euro\Tests\Unit;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use WMDE\Euro\Euro;
 
@@ -248,6 +249,51 @@ class EuroTest extends TestCase {
 
 	public function test9001centsDoesNotEqual9000cents() {
 		$this->assertFalse( Euro::newFromCents( 9001 )->equals( Euro::newFromCents( 9000 ) ) );
+	}
+
+	/**
+	 * @dataProvider tooLongStringProvider
+	 */
+	public function testNewFromStringThrowsExceptionWhenStringIsTooLong( string $string ) {
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Number is too big' );
+
+		Euro::newFromString( $string );
+	}
+
+	public function tooLongStringProvider() {
+		yield [ '1111111111111111111111111111111' ];
+		yield [ (string)PHP_INT_MAX ];
+		yield [ substr( (string)PHP_INT_MAX, 0, -2 ) ];
+	}
+
+	public function testNewFromStringHandlesLongStrings() {
+		Euro::newFromString( substr( (string)PHP_INT_MAX, 0, -3 ) );
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * @dataProvider tooHighIntegerProvider
+	 */
+	public function testNewFromIntThrowsExceptionWhenIntegerIsTooHigh( int $int ) {
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Number is too big' );
+		Euro::newFromInt( $int );
+	}
+
+	public function tooHighIntegerProvider() {
+		yield [ PHP_INT_MAX ];
+		yield [ PHP_INT_MAX / 10 ];
+		yield [ PHP_INT_MAX / 100 ];
+	}
+
+	public function testNewFromIntHandlesBigIntegers() {
+		$number = (int)floor( PHP_INT_MAX / 101 );
+
+		$this->assertSame(
+			$number * 100,
+			Euro::newFromInt( $number )->getEuroCents()
+		);
 	}
 
 }

--- a/tests/Unit/EuroTest.php
+++ b/tests/Unit/EuroTest.php
@@ -273,7 +273,7 @@ class EuroTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider tooHighIntegerProvider
+	 * @dataProvider tooHighNumberProvider
 	 */
 	public function testNewFromIntThrowsExceptionWhenIntegerIsTooHigh( int $int ) {
 		$this->expectException( InvalidArgumentException::class );
@@ -281,13 +281,24 @@ class EuroTest extends TestCase {
 		Euro::newFromInt( $int );
 	}
 
-	public function tooHighIntegerProvider() {
+	public function tooHighNumberProvider() {
 		yield [ PHP_INT_MAX ];
 		yield [ PHP_INT_MAX / 10 ];
 		yield [ PHP_INT_MAX / 100 ];
 	}
 
+	/**
+	 * @dataProvider tooHighNumberProvider
+	 */
+	public function testNewFromFloatThrowsExceptionWhenFloatIsTooHigh( int $int ) {
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Number is too big' );
+		Euro::newFromFloat( (float)$int );
+	}
+
 	public function testNewFromIntHandlesBigIntegers() {
+		// Edge case test for the highest allowed value (Euro::CENTS_PER_EURO +1 )
+		// 100 (Euro::CENTS_PER_EURO) does not work due to rounding
 		$number = (int)floor( PHP_INT_MAX / 101 );
 
 		$this->assertSame(


### PR DESCRIPTION
Did not deal with newFromFloat yet.
For floats there is PHP_FLOAT_DIG, added in PHP 7.2