### PR TITLE
Add string casting / JSON serialization to Euro class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
 	"homepage": "https://github.com/wmde/Euro",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": ">=7.1"
+		"php": ">=7.1",
+		"ext-json": "*"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~6.2",

--- a/src/Euro.php
+++ b/src/Euro.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-final class Euro {
+final class Euro implements \JsonSerializable {
 
 	private const DECIMAL_COUNT = 2;
 	private const CENTS_PER_EURO = 100;
@@ -33,6 +33,13 @@ final class Euro {
 	 * @return string
 	 */
 	public function __toString(): string {
+		return $this->getEuroString();
+	}
+
+	/**
+	 * @return string
+	 */
+	public function jsonSerialize(): string {
 		return $this->getEuroString();
 	}
 

--- a/src/Euro.php
+++ b/src/Euro.php
@@ -30,6 +30,13 @@ final class Euro {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function __toString(): string {
+		return $this->getEuroString();
+	}
+
+	/**
 	 * @param int $cents
 	 * @return self
 	 * @throws InvalidArgumentException

--- a/tests/Unit/EuroTest.php
+++ b/tests/Unit/EuroTest.php
@@ -91,7 +91,7 @@ class EuroTest extends TestCase {
 		$this->assertSame( '12.34', $amount->getEuroString() );
 	}
 
-	public function testGiven1234Cents_stringCastingReturns98euro76() {
+	public function testGiven9876Cents_stringCastingReturns98euro76() {
 		$amount = Euro::newFromCents( 9876 );
 		$this->assertSame( '98.76', (string) $amount );
 	}

--- a/tests/Unit/EuroTest.php
+++ b/tests/Unit/EuroTest.php
@@ -96,6 +96,11 @@ class EuroTest extends TestCase {
 		$this->assertSame( '98.76', (string) $amount );
 	}
 
+	public function testGivenEuroAmount_jsonEncodeWillEncodeProperly() {
+		$amount = Euro::newFromCents( 9876 );
+		$this->assertSame( '"98.76"', json_encode( $amount ) );
+	}
+
 	public function testOneEuroString_getsTurnedInto100cents() {
 		$this->assertSame( 100, Euro::newFromString( '1.00' )->getEuroCents() );
 	}

--- a/tests/Unit/EuroTest.php
+++ b/tests/Unit/EuroTest.php
@@ -91,6 +91,11 @@ class EuroTest extends TestCase {
 		$this->assertSame( '12.34', $amount->getEuroString() );
 	}
 
+	public function testGiven1234Cents_stringCastingReturns98euro76() {
+		$amount = Euro::newFromCents( 9876 );
+		$this->assertSame( '98.76', (string) $amount );
+	}
+
 	public function testOneEuroString_getsTurnedInto100cents() {
 		$this->assertSame( 100, Euro::newFromString( '1.00' )->getEuroCents() );
 	}


### PR DESCRIPTION
Since we use Euro amounts in Twig templates to further send them on to Vue, it would be really convenient if the Euro class would support string casting and serialization.