### PR TITLE
Remove ockcyp/covers-validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~9.0",
-		"wmde/fundraising-phpcs": "~6.0",
-		"ockcyp/covers-validator": "~1.2"
+		"wmde/fundraising-phpcs": "~6.0"
 	},
 	"repositories": [
 		{
@@ -36,7 +35,6 @@
 		],
 		"test": [
 			"composer validate --no-interaction",
-			"vendor/bin/covers-validator",
 			"vendor/bin/phpunit"
 		],
 		"cs": [


### PR DESCRIPTION
The tool is not compatible with PHPUnit 9.x and the coverage check
provided by it is no longer needed (it's done by PHPUnit)
