### PR TITLE
Add getEuros method

### DIFF
--- a/src/Euro.php
+++ b/src/Euro.php
@@ -153,6 +153,10 @@ final class Euro implements \JsonSerializable {
 		return $this->cents / self::CENTS_PER_EURO;
 	}
 
+	public function getEuros(): int {
+		return intval( $this->cents / self::CENTS_PER_EURO );
+	}
+
 	/**
 	 * Returns the euro amount as string with two decimals always present in format "42.00".
 	 *

--- a/tests/Unit/EuroTest.php
+++ b/tests/Unit/EuroTest.php
@@ -57,6 +57,29 @@ class EuroTest extends TestCase {
 		$this->assertExactFloat( 0.33, $amount->getEuroFloat() );
 	}
 
+	/**
+	 * @dataProvider getEurosDataProvider
+	 */
+	public function testGetEurosReturnsCorrectValues( int $cents, int $expectedEuros ) {
+		$amount = Euro::newFromCents( $cents );
+		$this->assertEquals( $expectedEuros, $amount->getEuros() );
+	}
+
+	public function getEurosDataProvider(): array {
+		return [
+			[ 0, 0 ],
+			[ 3, 0 ],
+			[ 102, 1 ],
+			[ 149, 1 ],
+			[ 150, 1 ],
+			[ 151, 1 ],
+			[ 199, 1 ],
+			[ 555, 5 ],
+			[ 1033, 10 ],
+			[ 9999, 99 ],
+		];
+	}
+
 	public function testGivenNegativeAmount_constructorThrowsException() {
 		$this->expectException( \InvalidArgumentException::class );
 		Euro::newFromCents( -1 );


### PR DESCRIPTION
Membership Applications store the floored euro amount and currently converts the return value from getEuroFloat(). This PR internalises the functionality.

PR: https://github.com/wmde/fundraising-memberships/pull/100
Ticket: https://phabricator.wikimedia.org/T305051