### PR TITLE
Remove badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,10 @@
 # Euro
 
-[![Build Status](https://secure.travis-ci.org/wmde/Euro.png?branch=master)](http://travis-ci.org/wmde/Euro)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/wmde/Euro/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/wmde/Euro/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/wmde/Euro/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/wmde/Euro/?branch=master)
-[![Latest Stable Version](https://poser.pugx.org/wmde/euro/version.png)](https://packagist.org/packages/wmde/euro)
-[![Download count](https://poser.pugx.org/wmde/euro/d/total.png)](https://packagist.org/packages/wmde/euro)
-
 [Value Object](https://en.wikipedia.org/wiki/Value_object) that represents a positive amount of Euro.
 
 ## Installation
 
-To add this package as a local, per-project dependency to your project, simply add a
+To add this package as a local, per-project dependency to your project, add a
 dependency on `wmde/euro` to your project's `composer.json` file.
 Here is a minimal example of a `composer.json` file that just defines a dependency on
 Euro 1.x:


### PR DESCRIPTION
We're no longer using Travis, the generated ones are broken and we'll
remove Scrutinizer soon.
